### PR TITLE
[WIP] List hackathons and implement pagination

### DIFF
--- a/app/(home)/hackathons/page.tsx
+++ b/app/(home)/hackathons/page.tsx
@@ -1,9 +1,88 @@
-import React from 'react'
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
+import { ArrowUpRight } from "lucide-react";
+import Link from "next/link";
 
-export default function HomePage(): React.ReactElement {
+export default async function HackathonPage({
+  searchParams,
+}: {
+  searchParams?: { page?: string };
+}) {
+  const page = Number(searchParams?.page ?? 1);
+  const pageSize = 10;
+
+  const res = await fetch(
+    `https://avalanche-docs-eight.vercel.app/api/hackathons?page=${page}&pageSize=${pageSize}`,
+    {
+      cache: "no-store",
+    }
+  );
+
+  if (!res.ok) {
+    throw new Error("Failed to fetch hackathons");
+  }
+
+  const { hackathons, total } = await res.json();
+  const totalPages = Math.ceil(total / pageSize);
+
   return (
-    <main className="container relative mx-auto px-4 py-12 space-y-24">
-      <h1>Hackathons</h1>
+    <main className="container mx-auto px-4 py-12 space-y-6">
+      <h1 className="text-2xl font-bold">Hackathons</h1>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        {hackathons.map((hackathon: any) => (
+          <Card
+            key={hackathon.id}
+            className="hover:shadow-md transition-shadow"
+          >
+            <CardHeader>
+              <CardTitle>{hackathon.title}</CardTitle>
+              {/* <CardDescription>{hackathon.description}</CardDescription> */}
+            </CardHeader>
+            <CardContent>
+              <p>
+                <strong>Date:</strong> {hackathon.date.split("T")[0]}
+              </p>
+
+              <p>
+                <strong>Type:</strong> {hackathon.type}
+              </p>
+              <p>
+                <strong>City:</strong> {hackathon.city}
+              </p>
+              <p>
+                <strong>Total Prizes:</strong> ${hackathon.total_prizes}
+              </p>
+            </CardContent>
+            <CardFooter>
+              <Button variant="outline" className="ml-auto">
+                Learn More
+                <ArrowUpRight />
+              </Button>
+            </CardFooter>
+          </Card>
+        ))}
+      </div>
+
+      <div className="flex justify-center gap-4">
+        {page > 1 && (
+          <Link href={`/hackathons?page=${page - 1}`}>
+            <Button>Previous</Button>
+          </Link>
+        )}
+        {page < totalPages && (
+          <Link href={`/hackathons?page=${page + 1}`}>
+            <Button>Next</Button>
+          </Link>
+        )}
+      </div>
     </main>
-  )
+  );
 }

--- a/app/api/hackathons/[id]/route.ts
+++ b/app/api/hackathons/[id]/route.ts
@@ -1,0 +1,10 @@
+import { HackathonsList } from "@/types/hackathons";
+import { NextResponse } from "next/server";
+
+
+export async function GET(req: Request, { params }: { params: Promise<{ id: string }> }) {
+    const id = (await params).id
+    const hackathon = HackathonsList.find(hackathon => hackathon.id === id);
+    return NextResponse.json(hackathon)
+
+}

--- a/app/api/hackathons/route.ts
+++ b/app/api/hackathons/route.ts
@@ -2,37 +2,31 @@ import { NextRequest } from "next/dist/server/web/spec-extension/request";
 import { NextResponse } from "next/server";
 
 const hackathons: HackathonLite[] = Array.from({ length: 50 }, (_, index) => ({
-    id: `hackathon-${index + 1}`,
-    title: `Hackathon ${index + 1}`,
-    description: `This is the description for Hackathon ${index + 1}.`,
-    date: `2025-02-${(index % 28) + 1}T10:00:00Z`,
-    type: index % 2 === 0 ? "Virtual" : "On-site",
-    city: index % 2 === 0 ? "Online" : `City ${index + 1}`,
-    total_prizes: 5000.00 + index * 100
+  id: `hackathon-${index + 1}`,
+  title: `Hackathon ${index + 1}`,
+  description: `This is the description for Hackathon ${index + 1}.`,
+  date: `2025-02-${(index % 28) + 1}T10:00:00Z`,
+  type: index % 2 === 0 ? "Virtual" : "On-site",
+  city: index % 2 === 0 ? "Online" : `City ${index + 1}`,
+  total_prizes: 5000.0 + index * 100,
 }));
 
-
 export async function GET(req: NextRequest) {
+  const { searchParams } = req.nextUrl;
 
-    const { searchParams } = req.nextUrl
+  const page = searchParams.get("page") ?? "1";
+  const pageSize = searchParams.get("pageSize") ?? "10";
 
-    const page = searchParams.get('page') ?? "1";
-    const pageSize = searchParams.get('pageSize') ?? "10";
+  const pageNumber = parseInt(page as string) || 1;
+  const pageSizeNumber = parseInt(pageSize as string) || 10;
 
-    const pageNumber = parseInt(page as string) || 1;
-    const pageSizeNumber = parseInt(pageSize as string) || 10;
+  const startIndex = (pageNumber - 1) * pageSizeNumber;
+  const endIndex = startIndex + pageSizeNumber;
 
+  const paginatedHackathons = hackathons.slice(startIndex, endIndex);
 
-    const startIndex = (pageNumber - 1) * pageSizeNumber;
-    const endIndex = startIndex + pageSizeNumber;
-
-    const paginatedHackathons = hackathons.slice(startIndex, endIndex);
-
-
-    return NextResponse.json({
-        hackathons: paginatedHackathons,
-        total: hackathons.length
-    })
-
-
+  return NextResponse.json({
+    hackathons: paginatedHackathons,
+    total: hackathons.length,
+  });
 }

--- a/types/hackathons.ts
+++ b/types/hackathons.ts
@@ -1,70 +1,69 @@
 interface HackathonLite {
-    id: string;
-    title: string;
-    description: string;
-    date: string; // ISO timestamp
-    type: "Virtual" | "On-site";
-    city?: string;
-    total_prizes?: number; // decimal
-  }
+  id: string;
+  title: string;
+  description: string;
+  date: string; // ISO timestamp
+  type: "Virtual" | "On-site";
+  city?: string;
+  total_prizes?: number; // decimal
+}
 
 interface Hackathon {
-    id: string; // uuid
-    title: string;
-    description: string;
-    agenda: HackathonActivity[];
-    date: string; // ISO timestamp
-    registration_deadline: string; // ISO timestamp
-    type: "Virtual" | "On-site";
-    city?: string;
-    address?: string;
-    total_prizes?: number; // decimal
-    partners: Partner[];
-    tracks: Track[];
-  }
-  
-  interface HackathonActivity {
-    stage: string;
-    date: string; // ISO timestamp
-    duration: string; // ISO 8601 duration (e.g., PT2H)
-    name: string;
-    description: string;
-  }
-  
-  interface Track {
-    name: string;
-    description: string;
-    prizes: TrackPrize[];
-    total_reward: number; // decimal
-    partner?: string; // uuid
-    resources: Resource[];
-  }
-  
-  interface TrackPrize {
-    name: string;
-    description: string;
-    type: "Pool" | "Ranked";
-    criteria: string;
-    resources: Resource[];
-    rewards: number[]; // Array of decimal values
-  }
-  
-  interface Resource {
-    name: string;
-    icon: string;
-    link: string;
-  }
-  
-  interface Reward {
-    position: number;
-    description?: string;
-    reward_value: number; // decimal
-  }
-  
-  interface Partner {
-    name: string;
-    about: string;
-    links: Resource[];
-    logo: string; // URL to the image
-  }
-  
+  id: string; // uuid
+  title: string;
+  description: string;
+  agenda: HackathonActivity[];
+  date: string; // ISO timestamp
+  registration_deadline: string; // ISO timestamp
+  type: "Virtual" | "On-site";
+  city?: string;
+  address?: string;
+  total_prizes?: number; // decimal
+  partners: Partner[];
+  tracks: Track[];
+}
+
+interface HackathonActivity {
+  stage: string;
+  date: string; // ISO timestamp
+  duration: string; // ISO 8601 duration (e.g., PT2H)
+  name: string;
+  description: string;
+}
+
+interface Track {
+  name: string;
+  description: string;
+  prizes: TrackPrize[];
+  total_reward: number; // decimal
+  partner?: string; // uuid
+  resources: Resource[];
+}
+
+interface TrackPrize {
+  name: string;
+  description: string;
+  type: "Pool" | "Ranked";
+  criteria: string;
+  resources: Resource[];
+  rewards: number[]; // Array of decimal values
+}
+
+interface Resource {
+  name: string;
+  icon: string;
+  link: string;
+}
+
+interface Reward {
+  position: number;
+  description?: string;
+  reward_value: number; // decimal
+}
+
+interface Partner {
+  name: string;
+  about: string;
+  links: Resource[];
+  logo: string; // URL to the image
+}


### PR DESCRIPTION
No puedo referenciar directamente [https://github.com/Voyager-Ship/SuperChainRaffle/issues/7] pero no importa.

Así se va viendo (hice zoomout):
![Screenshot 2025-01-28 005547](https://github.com/user-attachments/assets/003a19fd-7425-4eb7-b898-894d765b1743)

Small/md screens:
![Screenshot 2025-01-28 010221](https://github.com/user-attachments/assets/fa067401-72bd-4627-b056-501674e65de0)

Ejemplo de página similar a EthGlobal:
![Screenshot 2025-01-28 000448](https://github.com/user-attachments/assets/418d0534-455e-4509-a098-6ce158aef960)


Listo:
- [x] Listado de hackathones consumiendo la mock API
- [x] Paginado mostrando 10 elementos por página
- [x] Responsive muestra 1 o 3 elementos por row según el screen size
Pendiente:
- [ ] Implementar filtros de fecha, ubicación y estado (tiene sentido filtrar por cada una de las ubicaciones o por online/in person?
- [ ] Darle estilo a los botones de paginación, agregar info pills (upcoming, virtual/in person) e incluir sugerencias de estilizado para las cards

Preguntas y comentarios para Sebastian:
- tiene sentido filtrar por cada una de las ubicaciones o por online/in person?
- Se podría corregir la fecha para que los dias 1 al 9 del mes incluyan un 0? Es decir en lugar de "2025-02-1T10:00:00Z" que sea "2025-02-01T10:00:00Z" así puedo más fácil meter una función para darles formato y desplegar: "February 02, 2025" o similar
- Hablando de fechas, vamos a mostrar siempre una sola fecha como start date? He visto en EthGlobal y otra que despliegan fecha de inicio y fecha de final.
- En algún momento vamos a tener un campo string para la URL de algun ícono o imagen para el evento? Como es el caso de EthGlobal y la plataforma de la imagen.
- Podemos hacer más ajustes al card que yo creo que si se requieren. Por lo pronto no estoy desplegando la descripción y quizás el $ total de premios sea para el detalle del hackathon. Lo podemos hablar mañana/miercoles.