### PR TITLE
refactor: update badge assignment logic and schema

### DIFF
--- a/lib/auth/authOptions.ts
+++ b/lib/auth/authOptions.ts
@@ -130,7 +130,7 @@ export const AuthOptions: NextAuthOptions = {
         if (account?.provider == 'github') {
           await badgeAssignmentService.assignBadge({
             userId: dbUser.id,
-            requirementId: 'c21d8d8d-47ae-46e9-9df0-bfebf77bf58e',
+            requirementId: 'GitHub',
             category: BadgeCategory.requirement,
           });
          

--- a/prisma/migrations/20250910144937_delete_fields_from_badge_table/migration.sql
+++ b/prisma/migrations/20250910144937_delete_fields_from_badge_table/migration.sql
@@ -1,0 +1,47 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `points` on the `Badge` table. All the data in the column will be lost.
+  - You are about to drop the column `requirements_snapshot` on the `UserBadge` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Badge" DROP COLUMN "points";
+
+-- AlterTable
+ALTER TABLE "UserBadge" DROP COLUMN "requirements_snapshot";
+
+-- CreateTable
+CREATE TABLE "NodeRegistration" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "subnet_id" TEXT NOT NULL,
+    "blockchain_id" TEXT NOT NULL,
+    "node_id" TEXT NOT NULL,
+    "node_index" INTEGER,
+    "public_key" TEXT NOT NULL,
+    "proof_of_possession" TEXT NOT NULL,
+    "rpc_url" TEXT NOT NULL,
+    "chain_name" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'active',
+    "created_at" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expires_at" TIMESTAMPTZ(3) NOT NULL,
+    "updated_at" TIMESTAMPTZ(3) NOT NULL,
+
+    CONSTRAINT "NodeRegistration_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "NodeRegistration_user_id_idx" ON "NodeRegistration"("user_id");
+
+-- CreateIndex
+CREATE INDEX "NodeRegistration_status_idx" ON "NodeRegistration"("status");
+
+-- CreateIndex
+CREATE INDEX "NodeRegistration_subnet_id_idx" ON "NodeRegistration"("subnet_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "NodeRegistration_user_id_subnet_id_node_index_key" ON "NodeRegistration"("user_id", "subnet_id", "node_index");
+
+-- AddForeignKey
+ALTER TABLE "NodeRegistration" ADD CONSTRAINT "NodeRegistration_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -143,7 +143,6 @@ model Badge {
   id          String         @id @default(uuid())
   name        String
   description String
-  points      Int
   image_path  String
   category    String
   requirements Json[]        @default([])
@@ -161,7 +160,6 @@ model UserBadge {
   awarded_at DateTime @default(now())
   awarded_by String?
   requirements_version Int              @default(1)
-  requirements_snapshot Json            @default("{}")
   evidence             Json?            
   status Int  @db.SmallInt
   @@unique([user_id, badge_id])

--- a/server/services/badge.ts
+++ b/server/services/badge.ts
@@ -134,7 +134,6 @@ export async function assignBadgeAcademy(
           awarded_by: "system",
           status: badgeStatus,
           requirements_version: 1,
-          requirements_snapshot: badgeRequirements,
           evidence: completedRequirements,
         },
       });
@@ -178,7 +177,7 @@ export async function getBadgeByCourseId(courseId: string): Promise<Badge[]> {
     id: badge.id,
     name: badge.name,
     description: badge.description,
-    points: badge.points,
+    points: 0,
     image_path: badge.image_path,
     category: badge.category,
     requirements: badge.requirements.map((requirement) =>
@@ -207,7 +206,7 @@ export async function getBadgesByHackathonId(
     id: badge.id,
     name: badge.name,
     description: badge.description,
-    points: badge.points,
+    
     image_path: badge.image_path,
     category: badge.category,
     requirements: badge.requirements.map((requirement) =>

--- a/server/services/rewardBoard.ts
+++ b/server/services/rewardBoard.ts
@@ -50,13 +50,15 @@ let badges=userBadges.map((userBadge) => {
     awarded_by: userBadge.awarded_by,
     name: userBadge.badge.name,
     description: userBadge.badge.description,
-    points: userBadge.badge.points,
+    points: 0, // Se calculará después
     image_path: userBadge.badge.image_path,
     category: userBadge.badge.category,
     evidence: userBadge.evidence,
     requirements: parsedRequirements,
   };
 });
+
+// Calcular los puntos totales basándose en los requirements del evidence
 badges.forEach((badge) => {
   if (Array.isArray(badge.evidence)) {
     badge.points = badge.evidence.reduce(
@@ -69,8 +71,11 @@ badges.forEach((badge) => {
       },
       0
     );
+  } else {
+    badge.points = 0;
   }
 });
+
   // Map the result to the UserBadge type, flattening the badge fields
   return badges as unknown as UserBadge[];
 }

--- a/server/services/socialBadge.ts
+++ b/server/services/socialBadge.ts
@@ -55,7 +55,7 @@ export async function assignBadgeByRequirement(
           awarded_by: awardedBy,
           status: BadgeAwardStatus.approved,
           requirements_version: 1,
-          requirements_snapshot: badge.requirements || [],
+          
           evidence: fulfilledRequirement ? [fulfilledRequirement] : [],
         },
       });
@@ -106,7 +106,7 @@ export async function getBadgesByRequirementId(
     id: badge.id,
     name: badge.name,
     description: badge.description,
-    points: badge.points,
+    
     image_path: badge.image_path,
     category: badge.category,
     requirements: badge.requirements?.map((requirement) =>

--- a/types/badge.ts
+++ b/types/badge.ts
@@ -19,7 +19,7 @@ export type Badge = {
     id: string
     name: string
     description: string
-    points: number
+    points?: number
     image_path: string
     category: string
     requirements?: Requirement[]


### PR DESCRIPTION
- Changed requirementId for GitHub badge assignment to a more descriptive value.
- Removed points and requirements_snapshot fields from Badge and UserBadge models to simplify the schema.
- Updated badge retrieval functions to set points to 0 and calculate them later based on evidence.
- Adjusted Badge type to make points optional, reflecting the changes in the schema.