### PR TITLE
refactor: update role permissions and clean up badge assignment logic

### DIFF
--- a/app/api/badge/assign/route.ts
+++ b/app/api/badge/assign/route.ts
@@ -28,7 +28,7 @@ export const POST = withAuth(async (req: NextRequest) => {
     
     // Use the user's name as awardedBy
     const badge = await badgeAssignmentService.assignBadge(body, session?.user.name || undefined);
-    console.log("badge assigned", badge);
+
     return NextResponse.json({ result: badge }, { status: 200 });
   } catch (error: any) {
     console.error('Error POST /api/badge/assign:', error.message);

--- a/app/api/project/set-winner/route.ts
+++ b/app/api/project/set-winner/route.ts
@@ -3,7 +3,7 @@ import { withAuthRole } from "@/lib/protectedRoute";
 import { SetWinner } from "@/server/services/set-project-winner";
 import { NextRequest, NextResponse } from "next/server";
 
-export const PUT = withAuthRole("hackathon_judge", async (req: NextRequest) => {
+export const PUT = withAuthRole("badge_admin", async (req: NextRequest) => {
   const body = await req.json();
   const session = await getAuthSession();
   const name = session?.user.name || "user";

--- a/components/profile/reward-board/component/reward-card.tsx
+++ b/components/profile/reward-board/component/reward-card.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import { BadgeCardProps } from "../types/badgeCard";
 import { Card, CardContent } from "@/components/ui/card";
 import "./reward-card.css";
+import { Separator } from "@/components/ui/separator";
 
 export const RewardCard = ({
   name,
@@ -98,11 +99,15 @@ export const RewardCard = ({
                         style={{textDecoration: requirement.unlocked ?  "line-through" : "none"}}
                         title={requirement.description}
                       >
-                        {requirement.description}: <span className="font-bold">{requirement.points} points</span>
+                        {requirement.description}: <span className="font-bold">{Number(requirement.points ?? 0)} points</span>
                       </span>
                     </li>
                   ))}
                 </ul>
+                <Separator className="bg-zinc-700 my-2"/>
+                <span className="font-bold">
+                  {requirements?.reduce((acc, requirement) => acc + Number(requirement.points ?? 0), 0)} points
+                </span>
               </div>
             </CardContent>
           </Card>

--- a/server/services/badgeAssignmentService.ts
+++ b/server/services/badgeAssignmentService.ts
@@ -92,8 +92,6 @@ export class BadgeAssignmentService {
   private determineBadgeCategory(body: AssignBadgeBody): BadgeCategory | null {
     // If category is already specified, use it
 
-    console.log("body", body);
-
     if (body.category !== undefined) {
       return body.category;
     }

--- a/server/services/badgeStrategy.ts
+++ b/server/services/badgeStrategy.ts
@@ -42,7 +42,7 @@ export class ProjectBadgeStrategy implements BadgeAssignmentStrategy {
 
   getRequiredRole(): string | null {
     // Project badges require hackathon_judge role
-    return "hackathon_judge";
+    return "badge_admin";
   }
 }
 

--- a/server/services/inviteProjectMember.ts
+++ b/server/services/inviteProjectMember.ts
@@ -23,11 +23,14 @@ export async function generateInvitation(
     throw new Error("Hackathon ID is required");
   }
 
+  // Remove duplicate emails to prevent multiple invitations to the same user
+  const uniqueEmails = [...new Set(emails)];
+  
   const project = await createProject(hackathonId, userId);
 
   const invitationLinks: invitationLink[] = [];
 
-  for (const email of emails) {
+  for (const email of uniqueEmails) {
     const invitationLink = await handleEmailInvitation(
       email,
       userId,
@@ -58,22 +61,18 @@ async function handleEmailInvitation(
     return;
   }
 
-  const existingMember = await findExistingMember(
+  // Use atomic upsert to prevent race conditions and duplicate members
+  const member = await createOrUpdateMemberAtomically(
     invitedUser,
     email,
     project.id
   );
 
-  if (isConfirmedMember(existingMember)) {
+  // Skip if member is already confirmed (no need to send invitation again)
+  if (member.status === "Confirmed") {
     return;
   }
 
-  const member = await createOrUpdateMember(
-    invitedUser,
-    email,
-    project.id,
-    existingMember
-  );
   const inviteLink = await sendInvitationEmail(
     member,
     email,
@@ -95,72 +94,46 @@ function isSelfInvitation(invitedUser: any, userId: string): boolean {
   return invitedUser?.id === userId;
 }
 
-async function findExistingMember(
+/**
+ * Atomic operation to create or update member using transaction to prevent race conditions
+ * Since there's no unique constraint at DB level, we use a transaction-based approach
+ */
+async function createOrUpdateMemberAtomically(
   invitedUser: any,
   email: string,
   projectId: string
 ) {
-  if (invitedUser) {
-    const member = await prisma.member.findFirst({
+  return await prisma.$transaction(async (tx) => {
+    // First, try to find existing member within transaction
+    const existingMember = await tx.member.findFirst({
       where: {
-        user_id: invitedUser?.id,
+        email,
         project_id: projectId,
       },
     });
 
-    return member;
-  }
-  const member = await prisma.member.findFirst({
-    where: {
-      email,
-      project_id: projectId,
-    },
-  });
-
-  return member;
-}
-
-function isConfirmedMember(member: any): boolean {
-  return member?.status === "Confirmed";
-}
-
-async function createOrUpdateMember(
-  invitedUser: any,
-  email: string,
-  projectId: string,
-  existingMember: any
-) {
-  if (existingMember) {
-    return updateExistingMember(existingMember, invitedUser);
-  }
-
-  return createNewMember(invitedUser, email, projectId);
-}
-
-async function updateExistingMember(existingMember: any, invitedUser: any) {
-  return prisma.member.update({
-    where: { id: existingMember.id },
-    data: {
-      role: "Member",
-      status: "Pending Confirmation",
-      ...(invitedUser ? { user_id: invitedUser.id } : {}),
-    },
-  });
-}
-
-async function createNewMember(
-  invitedUser: any,
-  email: string,
-  projectId: string
-) {
-  return prisma.member.create({
-    data: {
-      user_id: invitedUser?.id,
-      project_id: projectId,
-      role: "Member",
-      status: "Pending Confirmation",
-      email: email,
-    },
+    if (existingMember) {
+      // Update existing member
+      return await tx.member.update({
+        where: { id: existingMember.id },
+        data: {
+          role: "Member",
+          status: "Pending Confirmation",
+          ...(invitedUser ? { user_id: invitedUser.id } : {}),
+        },
+      });
+    } else {
+      // Create new member
+      return await tx.member.create({
+        data: {
+          user_id: invitedUser?.id,
+          project_id: projectId,
+          role: "Member",
+          status: "Pending Confirmation",
+          email: email,
+        },
+      });
+    }
   });
 }
 


### PR DESCRIPTION
- Changed the role required for the set-winner route from "hackathon_judge" to "badge_admin" to align with new role definitions.
- Removed unnecessary console logs in badge assignment service for cleaner code.
- Implemented unique email handling in the invitation process to prevent duplicate invitations.
- Enhanced member creation logic with atomic operations to avoid race conditions and ensure data integrity.